### PR TITLE
Improve LED blending and UI responsiveness

### DIFF
--- a/src/animations.cpp
+++ b/src/animations.cpp
@@ -13,7 +13,14 @@ float clamp(float value, float min, float max)
 void StripAnimation::setPixel(int index, led color)
 {
 
-    stripState->setPixel(index + startLED, color);
+    if (stripState->getAnimationCount() > 1)
+    {
+        stripState->blendPixel(index + startLED, color);
+    }
+    else
+    {
+        stripState->setPixel(index + startLED, color);
+    }
 }
 
 void ParticleAnimation::updateRandomParticles()

--- a/src/led_ui/debounceSlider.py
+++ b/src/led_ui/debounceSlider.py
@@ -49,7 +49,8 @@ class DebouncedSlider(QWidget):
 
         self.timer = QTimer(self)
         self.timer.setSingleShot(True)
-        self.timer.setInterval(100)
+        # Lower interval for more responsive UI updates
+        self.timer.setInterval(50)
         self.timer.timeout.connect(self._flush)
 
         self.slider.valueChanged.connect(self._on_change)

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -476,6 +476,28 @@ void StripState::setPixel(int index, led color)
     }
     leds[ledIndex] = CRGB(color.r, color.g, color.b);
 }
+
+void StripState::blendPixel(int index, led color)
+{
+    int ledIndex = (index % numLEDS + numLEDS) % numLEDS;
+    if (ledIndex < 0 || ledIndex >= numLEDS)
+    {
+        Serial.printf("Invalid LED index %d\n", ledIndex);
+        return;
+    }
+    int r = leds[ledIndex].r + color.r;
+    int g = leds[ledIndex].g + color.g;
+    int b = leds[ledIndex].b + color.b;
+
+    if (r > 255)
+        r = 255;
+    if (g > 255)
+        g = 255;
+    if (b > 255)
+        b = 255;
+
+    leds[ledIndex] = CRGB(r, g, b);
+}
 void StripState::setPixel(int index, int r, int g, int b)
 {
 

--- a/src/stripState.h
+++ b/src/stripState.h
@@ -88,6 +88,7 @@ public:
 
     void clearPixels();
     void clearPixel(int index);
+    void blendPixel(int index, led color);
     void setPixel(int index, led color);
     void setPixel(int index, int r, int g, int b);
 
@@ -95,6 +96,10 @@ public:
 
     void update();
     String getStripState();
+    int getAnimationCount()
+    {
+        return animations.size();
+    }
     bool respondToParameterMessage(parameter_message parameter);
 };
 


### PR DESCRIPTION
## Summary
- blend colors when multiple LED animations are active
- expose animation count via `StripState`
- add additive blending helper
- make UI slider throttle faster for more responsive updates

## Testing
- `python -m py_compile src/led_ui/debounceSlider.py`


------
https://chatgpt.com/codex/tasks/task_e_6866ea33b444832284adda4496f0a688