### PR TITLE
Add menu bar and simulation visibility toggle

### DIFF
--- a/src/led_ui/ledsimwidget.py
+++ b/src/led_ui/ledsimwidget.py
@@ -20,8 +20,7 @@ class LEDSimWidget(QWidget):
 
         self.simulate_checkbox = QCheckBox('Simulate')
         self.simulate_checkbox.setChecked(False)
-        self.simulate_checkbox.stateChanged.connect(lambda state: self.console.send_cmd(
-            f"simulate:{self.simCountSpinbox.value()}") if state == Qt.Checked else self.console.send_cmd("simulate:-1"))
+        self.simulate_checkbox.stateChanged.connect(self._sim_state_changed)
         self.scene = QGraphicsScene(self)
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing)
@@ -31,6 +30,16 @@ class LEDSimWidget(QWidget):
         self.layout.addWidget(self.simulate_checkbox)
         self.layout.addWidget(self.simCountSpinbox)
         self.layout.addWidget(self.view)
+        self._sim_state_changed(self.simulate_checkbox.checkState())
+
+    def _sim_state_changed(self, state):
+        enabled = state == Qt.Checked
+        if enabled:
+            self.console.send_cmd(
+                f"simulate:{self.simCountSpinbox.value()}")
+        else:
+            self.console.send_cmd("simulate:-1")
+        self.setVisible(enabled)
 
     def process_string(self, string):
         if string.startswith("sim:"):

--- a/src/led_ui/ledsimwidget.py
+++ b/src/led_ui/ledsimwidget.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGraphicsView, QGraphicsScene, QGraphicsEllipseItem, QCheckBox, QSpinBox, QHBoxLayout
+from PyQt5.QtWidgets import QWidget, QGraphicsView, QGraphicsScene, QGraphicsEllipseItem, QCheckBox, QSpinBox, QHBoxLayout
 from PyQt5.QtCore import Qt, pyqtSignal, QRectF, QSize
 from PyQt5.QtGui import QColor, QBrush, QPen, QPainter
 
@@ -18,16 +18,18 @@ class LEDSimWidget(QWidget):
         self.simCountSpinbox.setRange(-1, 10000)
         self.simCountSpinbox.setValue(1)
 
+        # hidden checkbox used for menu-driven simulation toggle
         self.simulate_checkbox = QCheckBox('Simulate')
         self.simulate_checkbox.setChecked(False)
         self.simulate_checkbox.stateChanged.connect(self._sim_state_changed)
+        self.simulate_checkbox.setVisible(False)
         self.scene = QGraphicsScene(self)
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing)
         self.view.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.view.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setMaximumHeight(64)
-        self.layout.addWidget(self.simulate_checkbox)
+        # checkbox isn't added to layout so users toggle via menu
         self.layout.addWidget(self.simCountSpinbox)
         self.layout.addWidget(self.view)
         self._sim_state_changed(self.simulate_checkbox.checkState())

--- a/src/led_ui/mainwindow.py
+++ b/src/led_ui/mainwindow.py
@@ -33,10 +33,6 @@ class MainWindow(QMainWindow):
         main_layout.addWidget(self.parameter_menu)
 
         self.console.setVisible(False)
-        self.toggle_console_btn = QPushButton("Toggle Console")
-        self.toggle_console_btn.clicked.connect(self.toggle_console)
-
-        main_layout.addWidget(self.toggle_console_btn)
         main_layout.addWidget(self.console)
         main_layout.addWidget(DeviceSelector(
             lambda port: self.console.connect(port), port))
@@ -53,6 +49,10 @@ class MainWindow(QMainWindow):
         save_action = QAction('Save Profile', self)
         save_action.triggered.connect(self.parameter_menu.save_profile)
         file_menu.addAction(save_action)
+
+        load_action = QAction('Load From Disk', self)
+        load_action.triggered.connect(self.parameter_menu.load_profile)
+        file_menu.addAction(load_action)
 
         confirm_action = QAction('Confirm Parameters', self)
         confirm_action.triggered.connect(

--- a/src/led_ui/parameter_menu.py
+++ b/src/led_ui/parameter_menu.py
@@ -303,14 +303,7 @@ class ParameterMenuWidget(QWidget):
         pRoot.addWidget(self.animationSender)
         paramHLayout.addWidget(self.tree, 1)
         paramHLayout.addWidget(self.pages, 1)
-        self.confirm = QPushButton("Confirm")
-        self.confirm.setIcon(qta.icon("fa5s.check"))
-        self.confirm.clicked.connect(
-            lambda: self.console.send_cmd("confirmParameters"))
-        paramHLayout.addWidget(self.confirm)
-        self.saveBtn = QPushButton("Save Profile")
-        self.saveBtn.clicked.connect(self.save_profile)
-        paramHLayout.addWidget(self.saveBtn)
+        # confirm and save buttons are now in the main menu
         self.tabs.addTab(paramTab, "Parameters")
 
         # Data tab -------------------------------------------------------
@@ -319,9 +312,7 @@ class ParameterMenuWidget(QWidget):
         self.dataList = QListWidget()
         self.dataList.itemDoubleClicked.connect(self._data_double_clicked)
         dRoot.addWidget(self.dataList)
-        self.loadBtn = QPushButton("Load From Disk")
-        self.loadBtn.clicked.connect(self.load_profile)
-        dRoot.addWidget(self.loadBtn)
+        # load from disk action moved to the File menu
         self.tabs.addTab(dataTab, "Data")
 
         self.setWindowTitle("ESP32 Pattern Controller")


### PR DESCRIPTION
## Summary
- create a menu bar with actions to save profile, confirm parameters and toggle UI items
- allow toggling verbose/echo from the menu
- hide the LED simulation widget unless simulation is enabled

## Testing
- `python -m py_compile src/led_ui/mainwindow.py src/led_ui/ledsimwidget.py`

------
https://chatgpt.com/codex/tasks/task_e_686711c2d6cc8322ac89c1ba9aaebb70