### PR TITLE
Add reset defaults and strip state query

### DIFF
--- a/src/animations.cpp
+++ b/src/animations.cpp
@@ -23,6 +23,27 @@ void StripAnimation::setPixel(int index, led color)
     }
 }
 
+String StripAnimation::describe()
+{
+    String desc = getAnimationName(animationType).c_str();
+    desc += " start:" + String(startLED);
+    desc += " end:" + String(endLED);
+
+    for (const auto &p : getIntParameters())
+    {
+        desc += " " + String(getParameterName(p.id).c_str()) + ":" + String(p.value);
+    }
+    for (const auto &p : getFloatParameters())
+    {
+        desc += " " + String(getParameterName(p.id).c_str()) + ":" + String(p.value, 2);
+    }
+    for (const auto &p : getBoolParameters())
+    {
+        desc += " " + String(getParameterName(p.id).c_str()) + ":" + String(p.value ? "1" : "0");
+    }
+    return desc;
+}
+
 void ParticleAnimation::updateRandomParticles()
 {
 

--- a/src/animations.h
+++ b/src/animations.h
@@ -67,6 +67,7 @@ public:
         return endLED;
     }
     void setPixel(int index, led color);
+    String describe();
 };
 
 #define NUM_PARTICLES 20

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -40,3 +40,7 @@ void ConfigManager::loadParameters(ParameterManager* pm) {
         pm->setFloat(p.id, val);
     }
 }
+
+void ConfigManager::clear() {
+    prefs.clear();
+}

--- a/src/config.h
+++ b/src/config.h
@@ -8,6 +8,7 @@ public:
     void begin();
     void saveParameters(ParameterManager* pm);
     void loadParameters(ParameterManager* pm);
+    void clear();
 private:
     Preferences prefs;
 };

--- a/src/ledManager.cpp
+++ b/src/ledManager.cpp
@@ -317,14 +317,14 @@ void LEDManager::toggleMode()
         stripStates[currentStrip - 1]->toggleMode();
     }
 }
-String LEDManager::getStripState()
+String LEDManager::getStripState(bool verbose)
 {
     int currentStrip = getInt(PARAM_CURRENT_STRIP);
     if (currentStrip == 0)
     {
-        return stripStates[0]->getStripState();
+        return stripStates[0]->getStripState(verbose);
     }
-    return stripStates[currentStrip - 1]->getStripState();
+    return stripStates[currentStrip - 1]->getStripState(verbose);
 }
 
 #endif

--- a/src/ledManager.h
+++ b/src/ledManager.h
@@ -27,7 +27,7 @@ public:
     bool handleLEDCommand(String command);
     void setLED(int ledIndex, led color);
     void toggleMode();
-    String getStripState();
+    String getStripState(bool verbose = false);
     int getCurrentStrip();
     std::vector<StripState*> &getStrips() { return stripStates; }
     bool respondToParameterMessage(parameter_message parameter);

--- a/src/led_ui/ledsimwidget.py
+++ b/src/led_ui/ledsimwidget.py
@@ -50,6 +50,9 @@ class LEDSimWidget(QWidget):
 
             self.update_leds(compressed_data)
             return True
+        if string.startswith("state:"):
+            print(string)
+            return True
         return False
 
     def update_leds(self, compressed_data):

--- a/src/led_ui/mainwindow.py
+++ b/src/led_ui/mainwindow.py
@@ -54,10 +54,18 @@ class MainWindow(QMainWindow):
         load_action.triggered.connect(self.parameter_menu.load_profile)
         file_menu.addAction(load_action)
 
+        reset_action = QAction('Reset Defaults', self)
+        reset_action.triggered.connect(lambda: self.console.send_cmd('resetDefaults'))
+        file_menu.addAction(reset_action)
+
         confirm_action = QAction('Confirm Parameters', self)
         confirm_action.triggered.connect(
             lambda: self.console.send_cmd('confirmParameters'))
         file_menu.addAction(confirm_action)
+
+        state_action = QAction('Get Strip State', self)
+        state_action.triggered.connect(lambda: self.console.send_cmd('getStripState'))
+        file_menu.addAction(state_action)
 
         view_menu = menu_bar.addMenu('View')
         self.sim_action = QAction('Show Simulation', self, checkable=True)

--- a/src/led_ui/parameter_menu.py
+++ b/src/led_ui/parameter_menu.py
@@ -499,3 +499,4 @@ class ParameterMenuWidget(QWidget):
             val = prm.get("value")
             cmd = f"p:{pid}:{val}"
             self.console.send_cmd(cmd)
+        self.console.send_cmd("saveDefaults")

--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -337,6 +337,18 @@ bool processCmd(String command)
     Serial.println("Defaults loaded");
     return true;
   }
+  if (command == "resetDefaults")
+  {
+    configManager.clear();
+    Serial.println("Defaults cleared");
+    return true;
+  }
+  if (command == "getStripState")
+  {
+    String state = ledManager->getStripState(true);
+    Serial.println("state:" + state);
+    return true;
+  }
   // ledManager->handleLEDCommand(command);
   // meshManager->handleMeshCommand(command);
   // checkLEDCommand(command);

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -65,9 +65,19 @@ void StripState::toggleMode()
     this->clearPixels();
 }
 
-String StripState::getStripState()
+String StripState::getStripState(bool verbose)
 {
-    return getLedStateName(ledState);
+    if (!verbose)
+    {
+        return getLedStateName(ledState);
+    }
+    String result = "strip" + String(stripIndex + 1) + " state:" + getLedStateName(ledState);
+    for (const auto &anim : animations)
+    {
+        result += " " + anim->describe();
+        result += ";";
+    }
+    return result;
 }
 
 std::unique_ptr<StripAnimation> makeAnimation(StripState *stripState, ANIMATION_TYPE animType, int startLED, int endLED, std::map<ParameterID, float> params)

--- a/src/stripState.h
+++ b/src/stripState.h
@@ -95,7 +95,7 @@ public:
     void toggleMode();
 
     void update();
-    String getStripState();
+    String getStripState(bool verbose = false);
     int getAnimationCount()
     {
         return animations.size();


### PR DESCRIPTION
## Summary
- allow clearing stored defaults with `resetDefaults`
- persist loaded profiles automatically from the UI
- expose LED animation configuration via `getStripState`
- show state messages in the LED simulator
- add menu items for resetting defaults and requesting strip state

## Testing
- `python3 -m py_compile src/led_ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68671741322c8322b4332e380d3cde1a