### PR TITLE
Fix parameter persistence in UI

### DIFF
--- a/src/led_ui/parameter_menu.py
+++ b/src/led_ui/parameter_menu.py
@@ -340,6 +340,7 @@ class ParameterMenuWidget(QWidget):
         self.setWindowTitle("ESP32 Pattern Controller")
         self.resize(760, 500)
         loadParameters()
+        self.update_widgets_from_map()
         self.refresh_data_files()
 
         stateTab = QWidget()

--- a/src/led_ui/parameter_menu.py
+++ b/src/led_ui/parameter_menu.py
@@ -22,6 +22,12 @@ ParameterMap: dict[str, dict] = {}
 ParameterIDMap: dict[int, str] = {}
 
 
+def save_parameter_map():
+    """Persist the current ParameterMap to disk."""
+    with open("parameter_map.json", "w") as f:
+        json.dump(ParameterMap, f, indent=2)
+
+
 # ───────────────────────────── MENU + PARAM ------------------------------------------------------------------
 # (unchanged skeleton – plug your full MENU_TREE and PARAM_MAP here)
 MENU_TREE = {
@@ -89,11 +95,7 @@ def checkParameters(params):
         ParameterMap[name] = prm
         ParameterIDMap[prm["id"]] = name
     print("parameters added to map:")
-    mapAsString = json.dumps(params, indent=2)
-
-    # save the map to a file
-    with open("parameter_map.json", "w") as f:
-        f.write(mapAsString)
+    save_parameter_map()
 
 
 def loadParameters():
@@ -208,6 +210,7 @@ class ParamPage(QWidget):
     def _send(self, pid, val):
         if pid in ParameterIDMap:
             ParameterMap[ParameterIDMap[pid]]["value"] = val
+            save_parameter_map()
         if (len(ParameterMap)):
             # send short version if available
             cmd = "p:" + str(pid) + ":" + str(val)
@@ -507,6 +510,7 @@ class ParameterMenuWidget(QWidget):
         ParameterMap.update(data)
         global ParameterIDMap
         ParameterIDMap = {v["id"]: k for k, v in ParameterMap.items()}
+        save_parameter_map()
         self.cache.clear()
         while self.pages.count():
             w = self.pages.widget(0)
@@ -541,3 +545,4 @@ class ParameterMenuWidget(QWidget):
                 pid = prm.get("id")
                 val = prm.get("value")
                 page.set_param_value(pid, val)
+        save_parameter_map()

--- a/src/led_ui/parameter_menu.py
+++ b/src/led_ui/parameter_menu.py
@@ -21,10 +21,12 @@ from shared import get_param_name
 ParameterMap: dict[str, dict] = {}
 ParameterIDMap: dict[int, str] = {}
 
+PARAM_MAP_FILE = os.path.join(os.path.dirname(__file__), "parameter_map.json")
+
 
 def save_parameter_map():
     """Persist the current ParameterMap to disk."""
-    with open("parameter_map.json", "w") as f:
+    with open(PARAM_MAP_FILE, "w") as f:
         json.dump(ParameterMap, f, indent=2)
 
 
@@ -101,7 +103,7 @@ def checkParameters(params):
 def loadParameters():
     """Load the parameters from a file."""
     try:
-        with open("parameter_map.json", "r") as f:
+        with open(PARAM_MAP_FILE, "r") as f:
             data = f.read()
             if data:
                 global ParameterMap, ParameterIDMap

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -83,20 +83,20 @@ String StripState::getStripState(bool verbose)
 
 String StripState::getStripStateJson(bool verbose)
 {
-    DynamicJsonDocument doc(2048);
+    JsonDocument doc;
     doc["type"] = "stripState";
     doc["strip"] = stripIndex + 1;
     doc["state"] = getLedStateName(ledState);
     if (verbose)
     {
-        JsonArray arr = doc.createNestedArray("animations");
+        JsonArray arr = doc["animations"].to<JsonArray>();
         for (const auto &anim : animations)
         {
-            JsonObject a = arr.createNestedObject();
+            JsonObject a = arr.add<JsonObject>();
             a["type"] = getAnimationName(anim->getAnimationType()).c_str();
             a["start"] = anim->getStartLED();
             a["end"] = anim->getEndLED();
-            JsonObject params = a.createNestedObject("params");
+            JsonObject params = a["params"].to<JsonObject>();
             for (const auto &p : anim->getIntParameters())
             {
                 params[getParameterName(p.id).c_str()] = p.value;


### PR DESCRIPTION
## Summary
- keep parameter_map.json updated with new values
- persist parameters after loading profiles and applying strip state

## Testing
- `python -m py_compile src/led_ui/debounceSlider.py src/led_ui/parameter_menu.py src/led_ui/mainwindow.py src/led_ui/serial_console.py`

------
https://chatgpt.com/codex/tasks/task_e_68672b8bcb30832292c3d0112acb683e