### PR TITLE
Add variable math in animation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Recent updates added a few LED patterns including a falling bricks build-up effe
 
 Parameter presets are stored under `src/led_ui/data/configurations` while animation script files live in `src/led_ui/data/animations`.  Presets now store only values that differ from the defaults in `parameter_map.json`.
 
-Animation scripts (`*.led`) begin with a `ConfigFile:` line naming the base parameter preset. Parameters listed under the `Parameters:` section override values from that preset and `Animations:` describes the sequence of animations for the strip.
+Animation scripts (`*.led`) begin with a `ConfigFile:` line naming the base parameter preset. Parameters listed under the `Parameters:` section override values from that preset and `Animations:` describes the sequence of animations for the strip.  A `Variables:` section may optionally appear before `Parameters:` to define reusable values that can be referenced elsewhere by name.  Variable values can include simple expressions using `+`, `-`, `*` and `/` and may reference previously defined variables.
 
 Within the UI, open an animation file and use the **Send** button to transmit it to the device. Newlines are encoded as `|` characters when sent via the `script:` command.
 

--- a/src/led_ui/data/animations/anim_1.led
+++ b/src/led_ui/data/animations/anim_1.led
@@ -1,6 +1,12 @@
 
+Variables:
+  BaseHue:120
+  Offset:30
+  Color:BaseHue + Offset
+  Speed:1.0 * 2
+
 Animations:
-    Particles spawn_rate:50
+    Particles hue:Color hue_end:Color spawn_rate:Speed
 
 PARAMETERS:
   brightness: 100


### PR DESCRIPTION
## Summary
- allow simple expressions in animation script variables
- note expression support in README
- update example animation script

## Testing
- `make -C tests` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868928d10c48322974453bd919159a4