### PR TITLE
Add node concept for LED strips

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -1,10 +1,27 @@
 this project is for controlling an esp32 from a PC via serial communication
 
 
-the esp32 code is in src
-the UI is located in src/led_ui
+the cPP esp32 code is in src
+the pyqt base UI is located in src/led_ui
 
 for esp32 code:
+
+    the main purpose of slave.cpp is to manage several LED strips. and respond to different messages from serial or ESPnow
+
     shared.h has most of the definitions of types
-    the esp can sendParameters to generate a parameter_map.json in src/led_ui to sync up the type definitions
+        important types are ANIMATION_TYPE,ParameterID,BoolParameter,FloatParameter,IntParameter,MenuID,LED_STATE
+
+   
+
+    ledManager.h deals with FastLED and initializes with a set of StripStates
+    stripState.h each strip represents one connection to esp32 pin
+        stripState has a RGB array connected to FastLED and manages a set of animations that can draw on the strips
+    animations.h animations are derived from StripAnimation
+        animation has a start and end led. setting position within animations works within that range
+    parameterManager.h 
+        base class that stores a set of parameters. int,float,bool
+        class knows how to parse and encode data to send between devices
+        most objects inherit from this to use functions getFloat,getBool.. etc
+        the esp can confirm parameters to the UI to generate a parameter_map.json in src/led_ui to sync up the type definitions
+
     

--- a/src/ledManager.cpp
+++ b/src/ledManager.cpp
@@ -34,7 +34,7 @@ LEDManager::LEDManager(std::string slavename) : ParameterManager("LEDManager", {
     {
         LEDParams params = rig.strips[i];
 
-        StripState *strip = new StripState(params.state, params.numLEDS, params.stripIndex);
+        StripState *strip = new StripState(params.state, params.numLEDS, params.stripIndex, params.nodes);
         for (int j = 0; j < params.animations.size(); j++)
         {
             AnimationParams anim = params.animations[j];

--- a/src/ledManager.cpp
+++ b/src/ledManager.cpp
@@ -231,7 +231,7 @@ bool LEDManager::respondToParameterMessage(parameter_message parameter)
         // return stripStates[currentStrip]->respondToParameterMessage(parameter);
         for (int i = 0; i < stripStates.size(); i++)
         {
-            stripStates[i]->respondToParameterMessage(parameter)
+            stripStates[i]->respondToParameterMessage(parameter);
         }
     }
     return false;

--- a/src/led_ui/data/animations/BricksTest.led
+++ b/src/led_ui/data/animations/BricksTest.led
@@ -2,4 +2,4 @@ Animations:
     BRICKS width:3 hue:1 hue_end:1 hue_variance:0 reverse:true time_scale:20
     BRICKS width:3 hue:200 hue_end:200 hue_variance:0 time_scale:20
 Parameters:
-    brightness:100
+    brightness:10

--- a/src/led_ui/data/animations/new1.led
+++ b/src/led_ui/data/animations/new1.led
@@ -1,4 +1,4 @@
 ConfigFile:
 Parameters:
 Animations:
-    SingleColor hue:20 start:20 end: 40
+    SingleColor hue:20 start:23 end:42

--- a/src/led_ui/data/animations/test_nodes.led
+++ b/src/led_ui/data/animations/test_nodes.led
@@ -1,0 +1,7 @@
+Animations:
+    Rainbow end:n1 hue:150 time_scale:60
+    Nebula start:n1 end:n2 hue:10
+    Particles start:n2 end:n3 hue:240 time_scale:60 spawn:50
+    Nebula start:n3 hue:350
+Parameters:
+    brightness:10

--- a/src/shared.h
+++ b/src/shared.h
@@ -520,100 +520,45 @@ const std::map<ANIMATION_TYPE, String> ANIMATION_TYPE_NAMES = {
     {ANIMATION_TYPE_RANDOM_PARTICLES, "RANDOMPARTICLES"},
     {ANIMATION_TYPE_SINGLE_COLOR, "SINGLECOLOR"}};
 
+const LEDRig eclipse = {
+    "Eclipsicle",
+    {0x40, 0x91, 0x51, 0xFB, 0xB7, 0x48},
+    {
+        {0, 164, LED_STATE_SINGLE_ANIMATION, {
+                                                 {ANIMATION_TYPE_RAINBOW, 0, 163},
+                                             },
+         {32, 65, 90}},
+        {1, 200, LED_STATE_SINGLE_ANIMATION, {
+                                                 {ANIMATION_TYPE_SLIDER, 0, 200},
+                                             },
+         {32, 65, 90}},
+    },
+
+};
+const LEDRig tesseratic = {
+    "Tesseratica",
+    {0x40, 0x91, 0x51, 0xFB, 0xF7, 0xBC},
+    {
+        {0, 122, LED_STATE_MULTI_ANIMATION, {
+                                                {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
+                                            },
+         {28, 44, 72}},
+        {1, 122, LED_STATE_MULTI_ANIMATION, {
+                                                {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
+                                            },
+         {28, 44, 72}},
+        {2, 122, LED_STATE_MULTI_ANIMATION, {
+                                                {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
+                                            },
+         {28, 44, 72}},
+    },
+
+};
 const std::vector<LEDRig> slaves = {
-    {
-        "Eclipsicle",
-        {0x40, 0x91, 0x51, 0xFB, 0xB7, 0x48},
-        {
-            {0, 164, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_RAINBOW, 0, 163},
-                                                 }},
-            {1, 200, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_SLIDER, 0, 200},
-                                                 }},
+    eclipse,
+    tesseratic,
 
-        },
-    },
-    {
-        "Tesseratica",
-        {0x40, 0x91, 0x51, 0xFB, 0xF7, 0xBC},
-        {
-            {0, 122, LED_STATE_MULTI_ANIMATION, {
-                                                    {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
-
-                                                }},
-            {1, 122, LED_STATE_MULTI_ANIMATION, {
-                                                    {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
-
-                                                }},
-            {2, 122, LED_STATE_MULTI_ANIMATION, {
-                                                    {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
-
-                                                }},
-
-        },
-    },
-    {
-        "tradeday",
-        {0x40, 0x91, 0x51, 0xFB, 0xF7, 0xBC},
-        {
-            {0, 100, LED_STATE_SINGLE_ANIMATION, {}},
-        },
-    },
-    {
-        "simpled",
-        {0x40, 0x91, 0x51, 0xFB, 0xF7, 0xBC},
-        {
-            {0, 164, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_PARTICLES, 0, 164},
-                                                 }},
-
-        },
-    },
-    {
-        "Bike",
-        {0xD0, 0xEF, 0x76, 0x58, 0x45, 0xB4},
-        {
-            {0, 48, LED_STATE_SINGLE_ANIMATION, {
-                                                    {ANIMATION_TYPE_SLIDER, 0, 48},
-                                                }},
-            {1, 48, LED_STATE_SINGLE_ANIMATION, {
-                                                    {ANIMATION_TYPE_SLIDER, 0, 48},
-                                                }},
-            {2, 18, LED_STATE_SINGLE_ANIMATION, {
-                                                    {ANIMATION_TYPE_SLIDER, 0, 18},
-                                                }},
-        },
-    },
-    {
-
-        "Spinner",
-        {0xD0, 0xEF, 0x76, 0x58, 0x45, 0xB4},
-        {
-            {0, 280, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_IDLE, 0, 280},
-                                                 }},
-            {1, 280, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_IDLE, 0, 280},
-                                                 }},
-        },
-    },
-
-    {
-        "Bike",
-        {0xD0, 0xEF, 0x76, 0x57, 0x3F, 0xA0},
-        {
-            {0, 100, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_IDLE, 0, 100},
-                                                 }},
-            {1, 100, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_IDLE, 0, 100},
-                                                 }},
-            {2, 100, LED_STATE_SINGLE_ANIMATION, {
-                                                     {ANIMATION_TYPE_IDLE, 0, 100},
-                                                 }},
-        },
-    }};
+};
 const int LED_STATE_COUNT = LED_STATE_NAMES.size();
 
 void colorFromHSV(led &color, float h, float s, float v);

--- a/src/shared.h
+++ b/src/shared.h
@@ -488,6 +488,8 @@ struct LEDParams
     int numLEDS;
     LED_STATE state;
     std::vector<AnimationParams> animations;
+    // optional LED node positions dividing the strip
+    std::vector<int> nodes = {};
 };
 
 struct LEDRig

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -54,7 +54,9 @@ String rleCompresssCRGB(const CRGB *leds, int numLEDS)
     return result;
 }
 
-StripState::StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX) : ParameterManager(("Strip" + String(STRIP_INDEX + 1)).c_str(), {PARAM_CURRENT_STRIP, PARAM_SEQUENCE, PARAM_INVERT, PARAM_HUE, PARAM_CURRENT_LED}), ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX)
+StripState::StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX, std::vector<int> nodes)
+    : ParameterManager(("Strip" + String(STRIP_INDEX + 1)).c_str(), {PARAM_CURRENT_STRIP, PARAM_SEQUENCE, PARAM_INVERT, PARAM_HUE, PARAM_CURRENT_LED}),
+      ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX), nodes(nodes)
 
 {
     leds = new CRGB[numLEDS];
@@ -547,7 +549,19 @@ bool StripState::parseAnimationScript(String script)
                 }
                 if (k.equalsIgnoreCase("start"))
                 {
-                    start = v.toInt();
+                    if (v.equalsIgnoreCase("mid"))
+                    {
+                        start = getMidLed();
+                    }
+                    else if (v.startsWith("n"))
+                    {
+                        int idx = v.substring(1).toInt();
+                        start = getNode(idx);
+                    }
+                    else
+                    {
+                        start = v.toInt();
+                    }
                     if (isVerbose())
                     {
                         Serial.printf("\tstart = %d\n", start);
@@ -555,7 +569,19 @@ bool StripState::parseAnimationScript(String script)
                 }
                 else if (k.equalsIgnoreCase("end"))
                 {
-                    end = v.toInt();
+                    if (v.equalsIgnoreCase("mid"))
+                    {
+                        end = getMidLed();
+                    }
+                    else if (v.startsWith("n"))
+                    {
+                        int idx = v.substring(1).toInt();
+                        end = getNode(idx);
+                    }
+                    else
+                    {
+                        end = v.toInt();
+                    }
                     if (isVerbose())
                     {
                         Serial.printf("\tend = %d\n", end);

--- a/src/stripState.h
+++ b/src/stripState.h
@@ -24,6 +24,9 @@ private:
 
     float scrollPos = 0;
 
+    // led positions that divide the strip into segments
+    std::vector<int> nodes;
+
     std::vector<std::unique_ptr<StripAnimation>> animations;
     LED_STATE ledState = LED_STATE_IDLE;
 
@@ -31,7 +34,7 @@ public:
     bool isActive = true;
 
     CRGB *leds;
-    StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX);
+    StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX, std::vector<int> nodes = {});
 
     void setNumLEDS(int num)
     {
@@ -98,6 +101,11 @@ public:
     void update();
     String getStripState(bool verbose = false);
     String getStripStateJson(bool verbose = false);
+    int getMidLed() const { return numLEDS / 2; }
+    int getNode(int idx) const {
+        if (idx <= 0 || idx > nodes.size()) return 0;
+        return nodes[idx-1];
+    }
     int getAnimationCount()
     {
         return animations.size();


### PR DESCRIPTION
## Summary
- allow LED strips to define node divisions
- expose helper functions to fetch nodes and the midpoint
- parse `start`/`end` parameters from animation scripts using node names or `mid`

## Testing
- `make clean && make` in `tests`
- `./falling_bricks_test`

------
https://chatgpt.com/codex/tasks/task_e_6868e65d1f4c83228b8aa827feab6d51