### PR TITLE
Add 3D node support and visualizer

### DIFF
--- a/src/ledManager.cpp
+++ b/src/ledManager.cpp
@@ -34,7 +34,8 @@ LEDManager::LEDManager(std::string slavename) : ParameterManager("LEDManager", {
     {
         LEDParams params = rig.strips[i];
 
-        StripState *strip = new StripState(params.state, params.numLEDS, params.stripIndex, params.nodes);
+        StripState *strip = new StripState(params.state, params.numLEDS, params.stripIndex,
+                                           params.nodes, params.nodePositions);
         for (int j = 0; j < params.animations.size(); j++)
         {
             AnimationParams anim = params.animations[j];

--- a/src/ledManager.cpp
+++ b/src/ledManager.cpp
@@ -35,7 +35,7 @@ LEDManager::LEDManager(std::string slavename) : ParameterManager("LEDManager", {
         LEDParams params = rig.strips[i];
 
         StripState *strip = new StripState(params.state, params.numLEDS, params.stripIndex,
-                                           params.nodes, params.nodePositions);
+                                           params.nodes);
         for (int j = 0; j < params.animations.size(); j++)
         {
             AnimationParams anim = params.animations[j];

--- a/src/led_ui/environment.yml
+++ b/src/led_ui/environment.yml
@@ -12,3 +12,4 @@ dependencies:
       - qdarkstyle  # Optional: nice dark theme
       - qtawesome
       - pyqtgraph
+      - PyOpenGL

--- a/src/led_ui/environment.yml
+++ b/src/led_ui/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
       - qdarkstyle  # Optional: nice dark theme
       - qtawesome
+      - pyqtgraph

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -42,23 +42,33 @@ class LED3DWidget(QWidget):
         self.setVisible(enabled)
 
     def _rebuild_positions(self):
+        node_list = list(self.nodes)
+        if node_list:
+            last_idx = node_list[-1][0]
+            if last_idx < self.led_count:
+                first = node_list[0]
+                node_list.append((self.led_count, first[1], first[2], first[3]))
+
         pos = []
-        for i in range(len(self.nodes) - 1):
-            start_n = self.nodes[i]
-            end_n = self.nodes[i + 1]
+        for i in range(len(node_list) - 1):
+            start_n = node_list[i]
+            end_n = node_list[i + 1]
             start_i = start_n[0]
             end_i = end_n[0]
-            start_p = np.array(start_n[1:])
-            end_p = np.array(end_n[1:])
-            count = end_i - start_i
+            start_p = np.array(start_n[1:], dtype=float)
+            end_p = np.array(end_n[1:], dtype=float)
+            count = max(0, end_i - start_i)
             for j in range(count):
                 t = j / max(1, count)
                 p = start_p + t * (end_p - start_p)
                 pos.append(p)
-        self.positions = np.array(pos)
+        self.positions = np.array(pos, dtype=float)
 
     def _update_scatter(self):
-        colors = [QColor(r, g, b).getRgbF() for r, g, b in self.led_colors]
+        colors = np.array(
+            [QColor(r, g, b).getRgbF() for r, g, b in self.led_colors],
+            dtype=float,
+        )
         self.scatter.setData(pos=self.positions, size=5, color=colors)
 
     def process_string(self, string):

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -6,10 +6,10 @@ from PyQt5.QtGui import QColor
 import numpy as np
 
 class LED3DWidget(QWidget):
-    def __init__(self, console, node_positions, led_count):
+    def __init__(self, console, nodes, led_count):
         super().__init__()
         self.console = console
-        self.node_positions = node_positions
+        self.nodes = nodes
         self.led_count = led_count
         self.layout = QVBoxLayout(self)
 
@@ -42,13 +42,14 @@ class LED3DWidget(QWidget):
         self.setVisible(enabled)
 
     def _rebuild_positions(self):
-        idxs = [0] + [n for n in self.node_positions[1:]]
         pos = []
-        for i in range(len(self.node_positions) - 1):
-            start_i = idxs[i]
-            end_i = idxs[i+1]
-            start_p = np.array(self.node_positions[i])
-            end_p = np.array(self.node_positions[i+1])
+        for i in range(len(self.nodes) - 1):
+            start_n = self.nodes[i]
+            end_n = self.nodes[i + 1]
+            start_i = start_n[0]
+            end_i = end_n[0]
+            start_p = np.array(start_n[1:])
+            end_p = np.array(end_n[1:])
             count = end_i - start_i
             for j in range(count):
                 t = j / max(1, count)

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -1,0 +1,83 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QSpinBox
+from PyQt5.QtCore import Qt
+import pyqtgraph as pg
+import pyqtgraph.opengl as gl
+from PyQt5.QtGui import QColor
+import numpy as np
+
+class LED3DWidget(QWidget):
+    def __init__(self, console, node_positions, led_count):
+        super().__init__()
+        self.console = console
+        self.node_positions = node_positions
+        self.led_count = led_count
+        self.layout = QVBoxLayout(self)
+
+        self.simulate_checkbox = QCheckBox('Simulate')
+        self.simulate_checkbox.setChecked(False)
+        self.simCountSpinbox = QSpinBox()
+        self.simCountSpinbox.setRange(-1, 10000)
+        self.simCountSpinbox.setValue(1)
+        self.simulate_checkbox.stateChanged.connect(self._sim_state_changed)
+        self.layout.addWidget(self.simCountSpinbox)
+
+        self.view = gl.GLViewWidget()
+        self.layout.addWidget(self.view)
+        self.view.opts['distance'] = 4
+        self.scatter = gl.GLScatterPlotItem()
+        self.view.addItem(self.scatter)
+
+        self.led_colors = [(255, 0, 0)] * self.led_count
+        self._rebuild_positions()
+        self._update_scatter()
+        self._sim_state_changed(self.simulate_checkbox.checkState())
+
+    def _sim_state_changed(self, state):
+        enabled = state == Qt.Checked
+        if enabled:
+            self.console.send_cmd(
+                f"simulate:{self.simCountSpinbox.value()}")
+        else:
+            self.console.send_cmd("simulate:-1")
+        self.setVisible(enabled)
+
+    def _rebuild_positions(self):
+        idxs = [0] + [n for n in self.node_positions[1:]]
+        pos = []
+        for i in range(len(self.node_positions) - 1):
+            start_i = idxs[i]
+            end_i = idxs[i+1]
+            start_p = np.array(self.node_positions[i])
+            end_p = np.array(self.node_positions[i+1])
+            count = end_i - start_i
+            for j in range(count):
+                t = j / max(1, count)
+                p = start_p + t * (end_p - start_p)
+                pos.append(p)
+        self.positions = np.array(pos)
+
+    def _update_scatter(self):
+        colors = [QColor(r, g, b).getRgbF() for r, g, b in self.led_colors]
+        self.scatter.setData(pos=self.positions, size=5, color=colors)
+
+    def process_string(self, string):
+        if string.startswith("sim:"):
+            compressed_data = string.split("sim:")[1].strip()
+            self.led_colors = self.parse_rle(compressed_data)
+            self._update_scatter()
+            return True
+        return False
+
+    def parse_rle(self, data):
+        leds = []
+        for segment in data.split(";"):
+            if segment:
+                color, count = segment.split(":")
+                hc, vc = color.split(",")
+                hue_byte = int(hc)
+                hue = int(hue_byte * 359 / 255)
+                value = int(vc)
+                qcolor = QColor.fromHsv(hue, 255, value)
+                leds.extend([(qcolor.red(), qcolor.green(), qcolor.blue())] * int(count))
+        return leds
+

--- a/src/led_ui/mainwindow.py
+++ b/src/led_ui/mainwindow.py
@@ -29,7 +29,12 @@ class MainWindow(QMainWindow):
         self.led_sim_widget = LEDSimWidget(self.console)
         self.console.add_string_listener(self.led_sim_widget.process_string)
 
-        square_nodes = [(0,0,0),(1,0,0),(1,1,0),(0,1,0)]
+        square_nodes = [
+            (0, 0.0, 0.0, 0.0),
+            (10, 1.0, 0.0, 0.0),
+            (20, 1.0, 1.0, 0.0),
+            (30, 0.0, 1.0, 0.0),
+        ]
         self.led_3d_widget = LED3DWidget(self.console, square_nodes, 40)
         self.console.add_string_listener(self.led_3d_widget.process_string)
         self.led_3d_widget.setVisible(False)

--- a/src/led_ui/offline_main.py
+++ b/src/led_ui/offline_main.py
@@ -1,0 +1,25 @@
+# main.py
+
+import sys
+from PyQt5.QtWidgets import (
+    QApplication
+)
+
+from device_selector import DeviceSelector
+
+from mainwindow import MainWindow
+
+
+ 
+
+def start_app():
+    app = QApplication([])
+    win = MainWindow(None)
+    win.show()
+    app.win = win
+    app.exec_()
+
+
+if __name__ == '__main__':
+    print("Starting ESP32 LED Controller UI...")
+    start_app()

--- a/src/led_ui/sim_main.py
+++ b/src/led_ui/sim_main.py
@@ -1,0 +1,62 @@
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
+from led3dwidget import LED3DWidget
+
+class FakeConsole:
+    def __init__(self):
+        self.string_listeners = []
+        self.json_listeners = []
+        self.timer = QTimer()
+        self.timer.timeout.connect(self._tick)
+        self.hue = 0
+        self.running = False
+        self.led_count = 40
+
+    def add_string_listener(self, cb):
+        self.string_listeners.append(cb)
+
+    def add_json_listener(self, cb):
+        self.json_listeners.append(cb)
+
+    def send_cmd(self, cmd):
+        if cmd.startswith("simulate:"):
+            n = int(cmd.split(":")[1])
+            if n >= 0:
+                self.running = True
+                self.timer.start(100)
+            else:
+                self.running = False
+                self.timer.stop()
+        # print to console so user sees the command
+        print(f"fake send: {cmd}")
+
+    def send_json(self, data):
+        print(f"fake json: {data}")
+
+    def _tick(self):
+        if not self.running:
+            return
+        rle = f"{self.hue},255:{self.led_count};"
+        msg = f"sim:{rle}"
+        for cb in self.string_listeners:
+            cb(msg)
+        self.hue = (self.hue + 5) % 256
+
+
+def main():
+    app = QApplication([])
+    console = FakeConsole()
+    nodes = [
+        (0, 0.0, 0.0, 0.0),
+        (10, 1.0, 0.0, 0.0),
+        (20, 1.0, 1.0, 0.0),
+        (30, 0.0, 1.0, 0.0),
+    ]
+    widget = LED3DWidget(console, nodes, 40)
+    widget.show()
+    widget.simulate_checkbox.setChecked(True)
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared.h
+++ b/src/shared.h
@@ -496,10 +496,8 @@ struct LEDParams
     int numLEDS;
     LED_STATE state;
     std::vector<AnimationParams> animations;
-    // optional LED node positions dividing the strip
-    std::vector<int> nodes = {};
-    // 3D coordinates for each node in the same order as 'nodes'
-    std::vector<Node3D> nodePositions = {};
+    // nodes along the strip with optional 3D coordinates
+    std::vector<Node3D> nodes = {};
 };
 
 struct LEDRig
@@ -537,11 +535,11 @@ const LEDRig eclipse = {
         {0, 164, LED_STATE_SINGLE_ANIMATION, {
                                                  {ANIMATION_TYPE_RAINBOW, 0, 163},
                                              },
-         {32, 65, 90}, {}},
+         {{32,0,0,0},{65,0,0,0},{90,0,0,0}}},
         {1, 200, LED_STATE_SINGLE_ANIMATION, {
                                                  {ANIMATION_TYPE_SLIDER, 0, 200},
                                              },
-         {32, 65, 90}, {}},
+         {{32,0,0,0},{65,0,0,0},{90,0,0,0}}},
     },
 
 };
@@ -552,15 +550,15 @@ const LEDRig tesseratic = {
         {0, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}, {}},
+         {{28,0,0,0},{44,0,0,0},{72,0,0,0}}},
         {1, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}, {}},
+         {{28,0,0,0},{44,0,0,0},{72,0,0,0}}},
         {2, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}, {}},
+         {{28,0,0,0},{44,0,0,0},{72,0,0,0}}},
     },
 
 };
@@ -573,7 +571,6 @@ const LEDRig squareLoop = {
             {
                 {ANIMATION_TYPE_RAINBOW, 0, 39},
             },
-            {10,20,30},
             {
                 {0, 0.0f, 0.0f, 0.0f},
                 {10, 1.0f, 0.0f, 0.0f},

--- a/src/shared.h
+++ b/src/shared.h
@@ -481,6 +481,14 @@ struct AnimationParams
 
     std::map<ParameterID, float> params = {};
 };
+
+struct Node3D
+{
+    int index = 0; // LED index corresponding to this node
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
 struct LEDParams
 {
 
@@ -490,6 +498,8 @@ struct LEDParams
     std::vector<AnimationParams> animations;
     // optional LED node positions dividing the strip
     std::vector<int> nodes = {};
+    // 3D coordinates for each node in the same order as 'nodes'
+    std::vector<Node3D> nodePositions = {};
 };
 
 struct LEDRig
@@ -527,11 +537,11 @@ const LEDRig eclipse = {
         {0, 164, LED_STATE_SINGLE_ANIMATION, {
                                                  {ANIMATION_TYPE_RAINBOW, 0, 163},
                                              },
-         {32, 65, 90}},
+         {32, 65, 90}, {}},
         {1, 200, LED_STATE_SINGLE_ANIMATION, {
                                                  {ANIMATION_TYPE_SLIDER, 0, 200},
                                              },
-         {32, 65, 90}},
+         {32, 65, 90}, {}},
     },
 
 };
@@ -542,21 +552,42 @@ const LEDRig tesseratic = {
         {0, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}},
+         {28, 44, 72}, {}},
         {1, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}},
+         {28, 44, 72}, {}},
         {2, 122, LED_STATE_MULTI_ANIMATION, {
                                                 {ANIMATION_TYPE_PARTICLES, -1, -1, {{PARAM_HUE, 100}}},
                                             },
-         {28, 44, 72}},
+         {28, 44, 72}, {}},
+    },
+
+};
+
+const LEDRig squareLoop = {
+    "SquareLoop",
+    {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+    {
+        {0, 40, LED_STATE_SINGLE_ANIMATION,
+            {
+                {ANIMATION_TYPE_RAINBOW, 0, 39},
+            },
+            {10,20,30},
+            {
+                {0, 0.0f, 0.0f, 0.0f},
+                {10, 1.0f, 0.0f, 0.0f},
+                {20, 1.0f, 1.0f, 0.0f},
+                {30, 0.0f, 1.0f, 0.0f},
+            }
+        },
     },
 
 };
 const std::vector<LEDRig> slaves = {
     eclipse,
     tesseratic,
+    squareLoop,
 
 };
 const int LED_STATE_COUNT = LED_STATE_NAMES.size();

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -54,9 +54,12 @@ String rleCompresssCRGB(const CRGB *leds, int numLEDS)
     return result;
 }
 
-StripState::StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX, std::vector<int> nodes)
+StripState::StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX,
+                       std::vector<int> nodes,
+                       std::vector<Node3D> nodePositions)
     : ParameterManager(("Strip" + String(STRIP_INDEX + 1)).c_str(), {PARAM_CURRENT_STRIP, PARAM_SEQUENCE, PARAM_INVERT, PARAM_HUE, PARAM_CURRENT_LED}),
-      ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX), nodes(nodes)
+      ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX), nodes(nodes),
+      nodePositions(nodePositions)
 
 {
     leds = new CRGB[numLEDS];

--- a/src/stripState.cpp
+++ b/src/stripState.cpp
@@ -55,11 +55,9 @@ String rleCompresssCRGB(const CRGB *leds, int numLEDS)
 }
 
 StripState::StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX,
-                       std::vector<int> nodes,
-                       std::vector<Node3D> nodePositions)
+                       std::vector<Node3D> nodes)
     : ParameterManager(("Strip" + String(STRIP_INDEX + 1)).c_str(), {PARAM_CURRENT_STRIP, PARAM_SEQUENCE, PARAM_INVERT, PARAM_HUE, PARAM_CURRENT_LED}),
-      ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX), nodes(nodes),
-      nodePositions(nodePositions)
+      ledState(state), numLEDS(numLEDS), stripIndex(STRIP_INDEX), nodes(nodes)
 
 {
     leds = new CRGB[numLEDS];

--- a/src/stripState.h
+++ b/src/stripState.h
@@ -26,6 +26,8 @@ private:
 
     // led positions that divide the strip into segments
     std::vector<int> nodes;
+    // 3D coordinates for nodes
+    std::vector<Node3D> nodePositions;
 
     std::vector<std::unique_ptr<StripAnimation>> animations;
     LED_STATE ledState = LED_STATE_IDLE;
@@ -34,7 +36,9 @@ public:
     bool isActive = true;
 
     CRGB *leds;
-    StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX, std::vector<int> nodes = {});
+    StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX,
+               std::vector<int> nodes = {},
+               std::vector<Node3D> nodePositions = {});
 
     void setNumLEDS(int num)
     {
@@ -105,6 +109,13 @@ public:
     int getNode(int idx) const {
         if (idx <= 0 || idx > nodes.size()) return 0;
         return nodes[idx-1];
+    }
+    Node3D getNode3D(int idx) const {
+        if (idx <= 0 || idx > nodePositions.size()) return Node3D{};
+        return nodePositions[idx-1];
+    }
+    const std::vector<Node3D>& getNodePositions() const {
+        return nodePositions;
     }
     int getAnimationCount()
     {

--- a/src/stripState.h
+++ b/src/stripState.h
@@ -24,10 +24,8 @@ private:
 
     float scrollPos = 0;
 
-    // led positions that divide the strip into segments
-    std::vector<int> nodes;
-    // 3D coordinates for nodes
-    std::vector<Node3D> nodePositions;
+    // nodes with LED indices and 3D positions
+    std::vector<Node3D> nodes;
 
     std::vector<std::unique_ptr<StripAnimation>> animations;
     LED_STATE ledState = LED_STATE_IDLE;
@@ -37,8 +35,7 @@ public:
 
     CRGB *leds;
     StripState(LED_STATE state, const int numLEDS, int STRIP_INDEX,
-               std::vector<int> nodes = {},
-               std::vector<Node3D> nodePositions = {});
+               std::vector<Node3D> nodes = {});
 
     void setNumLEDS(int num)
     {
@@ -108,14 +105,14 @@ public:
     int getMidLed() const { return numLEDS / 2; }
     int getNode(int idx) const {
         if (idx <= 0 || idx > nodes.size()) return 0;
-        return nodes[idx-1];
+        return nodes[idx-1].index;
     }
     Node3D getNode3D(int idx) const {
-        if (idx <= 0 || idx > nodePositions.size()) return Node3D{};
-        return nodePositions[idx-1];
+        if (idx <= 0 || idx > nodes.size()) return Node3D{};
+        return nodes[idx-1];
     }
-    const std::vector<Node3D>& getNodePositions() const {
-        return nodePositions;
+    const std::vector<Node3D>& getNodes() const {
+        return nodes;
     }
     int getAnimationCount()
     {


### PR DESCRIPTION
## Summary
- store 3D coordinates for LED nodes via new `Node3D` struct
- include `nodePositions` in `LEDParams` and pass to `StripState`
- add example `SquareLoop` rig using 4 nodes with 3D positions
- expose node positions in `StripState`
- create `LED3DWidget` PyQt widget using pyqtgraph for orbitable 3D view
- integrate 3D widget into the main window
- update environment to install `pyqtgraph`

## Testing
- `make -C tests`
- `./tests/falling_bricks_test`

------
https://chatgpt.com/codex/tasks/task_e_6869749bfe408322b118d47be0776805