### PR TITLE
Add QEMU simulator environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ Animation scripts (`*.led`) begin with a `ConfigFile:` line naming the base para
 
 Within the UI, open an animation file and use the **Send** button to transmit it to the device. Newlines are encoded as `|` characters when sent via the `script:` command.
 
+### Simulating with QEMU
+
+PlatformIO can run the firmware under QEMU for automated testing.  An example
+environment called `esp32s3_qemu` is provided in `platformio.ini`.  Build and
+test it without uploading using:
+
+```bash
+pio test -e esp32s3_qemu --without-uploading
+```
+
+Refer to the [PlatformIO QEMU documentation](https://docs.platformio.org/en/latest/advanced/unit-testing/simulators/qemu.html)
+for more details on the simulator setup.
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ test it without uploading using:
 pio test -e esp32s3_qemu --without-uploading
 ```
 
+The `tool-qemu-xtensa` package used by this environment currently only
+provides binaries for Linux hosts. Windows users should run PlatformIO inside
+a WSL or other Linux environment in order to use QEMU.
+
 Refer to the [PlatformIO QEMU documentation](https://docs.platformio.org/en/latest/advanced/unit-testing/simulators/qemu.html)
 for more details on the simulator setup.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -102,7 +102,21 @@ lib_deps =
 
 [env:rgbw_test]
 build_flags = -D RGBW_TEST -D USE_LEDS
-lib_deps = 
-	adafruit/Adafruit NeoPixel@^1.12.2
-	fastled/FastLED@^3.6.0
-	 bblanchon/ArduinoJson@^7.0.4
+lib_deps =
+        adafruit/Adafruit NeoPixel@^1.12.2
+        fastled/FastLED@^3.6.0
+         bblanchon/ArduinoJson@^7.0.4
+
+[env:esp32s3_qemu]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+debug_tool = qemu
+platform_packages =
+    platformio/toolchain-xtensa32
+    platformio/tool-qemu-xtensa
+test_testing_command =
+    ${platformio.packages_dir}/tool-qemu-xtensa/bin/qemu-system-xtensa \
+    -nographic -machine esp32 \
+    -kernel ${platformio.build_dir}/${this.__env__}/firmware.elf
+


### PR DESCRIPTION
## Summary
- add `esp32s3_qemu` environment to `platformio.ini`
- document how to run firmware under QEMU

## Testing
- `make -C tests`
- `./tests/falling_bricks_test`

------
https://chatgpt.com/codex/tasks/task_e_6869920841f8832291dfe36145ec3c20