### PR TITLE
Improve particle tail smoothing

### DIFF
--- a/src/animations.cpp
+++ b/src/animations.cpp
@@ -85,50 +85,24 @@ void ParticleAnimation::updateRandomParticles()
 }
 void ParticleAnimation::fadeParticleTail(float position, int width, int hueStart, int hueEnd, int brightness, float fadeSpeed, int direction)
 {
-
-    // Serial.printf("Fading particle tail at position %g width %d hueStart %d hueEnd %d brightness %d fadeSpeed %f direction %d\n", position, width, hueStart, hueEnd, brightness, fadeSpeed, direction);
+    // Smoothly draw a fading trail behind the particle.
     for (int i = 0; i < width; i++)
     {
         int fadePos = position - i * direction;
-        // Serial.printf("fade %d\n", fadePos);
-        if (fadePos < 0 || fadePos > numLEDs())
+        if (fadePos < 0 || fadePos >= numLEDs())
         {
-
             continue;
         }
 
-        float t = (float)i / (float)width;
+        float t = static_cast<float>(i) / std::max(width - 1, 1);
+        float fade = 1.0f - t;      // start bright at the head
+        fade *= fade;               // quadratic falloff
+        fade = powf(fade, fadeSpeed); // user controlled exponent
 
-        if (t < 0.0f || t > 1.0f)
-        {
-            Serial.printf("Invalid fade time %f for particle tail %g %g\n", t, i, width);
-            continue;
-        }
+        float hue = interpolate(hueStart, hueEnd, t) / 360.0f;
+        float value = (brightness / 255.0f) * clamp(fade, 0.0f, 1.0f);
 
-        float fade;
-        if (t < 0.2f)
-        {
-            // Head: fade in quickly
-            fade = t / 0.2f;
-        }
-        else
-        {
-            // Tail: fade out smoothly
-            fade = 1.0f - ((t - 0.2f) / 0.8f);
-            fade = pow(fade, fadeSpeed); // apply fade curve
-        }
-        // Serial.printf("Fade position %d t %f fade %f\n", fadePos, t, fade);
-        float adjustedBrightness = brightness * fade;
-
-        // Add randomness in the tail
-        if (t >= 0.2f)
-        {
-            adjustedBrightness *= 0.9f + 0.2f * random(0, 1000) / 1000.0f; // ±10%
-        }
-
-        float hue = interpolate(hueStart, hueEnd, t) / 360.0f; // convert to 0-1 range
-
-        setPixelHSV(fadePos, hue, 1.0, adjustedBrightness / 255.0);
+        setPixelHSV(fadePos, hue, 1.0f, value);
     }
 }
 void ParticleAnimation::updateParticles()

--- a/src/animations.h
+++ b/src/animations.h
@@ -75,6 +75,17 @@ class ParticleAnimation : public StripAnimation
     Particle particles[NUM_PARTICLES];
     bool randomMode = false;
 
+    /**
+     * Draw a fading tail behind a particle.
+     *
+     * @param position   Current particle position in LED coordinates.
+     * @param width      Length of the tail in LEDs.
+     * @param hueStart   Hue at the head of the particle (degrees).
+     * @param hueEnd     Hue at the end of the tail (degrees).
+     * @param brightness Base brightness for the head (0-255).
+     * @param fadeSpeed  Exponent controlling how quickly the tail fades.
+     * @param direction  Direction of motion: 1 forward, -1 backward.
+     */
     void fadeParticleTail(float position, int width, int hueStart, int hueEnd, int brightness, float fadeSpeed, int direction);
 
     void spawnParticle(int position, float velocity, int hueStart, int hueEnd, int brightness, int width, int life);


### PR DESCRIPTION
## Summary
- smooth out particle tails
- document parameters for `fadeParticleTail`

## Testing
- `make clean && make` (fails: gtest missing)

------
https://chatgpt.com/codex/tasks/task_e_6869cbbb529c8322be5ddf994d2c6392