### PR TITLE
Add dynamic parameter expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Parameter presets are stored under `src/led_ui/data/configurations` while animat
 
 Animation scripts (`*.led`) begin with a `ConfigFile:` line naming the base parameter preset. Parameters listed under the `Parameters:` section override values from that preset and `Animations:` describes the sequence of animations for the strip.  A `Variables:` section may optionally appear before `Parameters:` to define reusable values that can be referenced elsewhere by name.  Variable values can include simple expressions using `+`, `-`, `*` and `/` and may reference previously defined variables.
 
+### Dynamic parameter expressions
+
+Scripts can also animate individual parameters over a loop by referencing the special time variable `t` inside an expression.  The loop length in seconds is defined by the variable `loop_length`.  Expressions may use `sin()`, `cos()` and `noise()` alongside arithmetic.  For example:
+
+```
+Variables:
+    loop_length:10
+Animations:
+    Rainbow hue:360*t
+```
+
+Here the hue parameter sweeps from 0–360 degrees over ten seconds.  Additional examples live under `src/led_ui/data/animations` such as `dynamic_particles.led` and `dynamic_noise_slider.led`.
+
 Within the UI, open an animation file and use the **Send** button to transmit it to the device. Newlines are encoded as `|` characters when sent via the `script:` command.
 
 ### Simulating with QEMU

--- a/src/led_ui/data/animations/dynamic_noise_slider.led
+++ b/src/led_ui/data/animations/dynamic_noise_slider.led
@@ -1,0 +1,6 @@
+Variables:
+    loop_length:8
+Animations:
+    Slider start:0 end:127 hue:200+noise(t*5)*50 width:3 speed:2
+Parameters:
+    brightness:180

--- a/src/led_ui/data/animations/dynamic_noise_slider.led
+++ b/src/led_ui/data/animations/dynamic_noise_slider.led
@@ -1,6 +1,6 @@
 Variables:
-    loop_length:8
+    loop_length:10
 Animations:
-    Slider start:0 end:127 hue:200+noise(t*5)*50 width:3 speed:2
+    Slider hue:250 width:40*sin(t*pi) position:10*cos(t*pi) speed:1 time_scale:10 brightness:10
 Parameters:
-    brightness:180
+    brightness:10

--- a/src/led_ui/data/animations/dynamic_particles.led
+++ b/src/led_ui/data/animations/dynamic_particles.led
@@ -1,6 +1,6 @@
 Variables:
-    loop_length:12
+    loop_length:4
 Animations:
-    Particles spawn_rate:5+5*sin(2*pi*t) hue:100+80*sin(2*pi*t)
+    Particles spawn_rate:50 hue:100+10*sin(2*pi*t) hue_end:100 time_scale:60
 Parameters:
     brightness:150

--- a/src/led_ui/data/animations/dynamic_particles.led
+++ b/src/led_ui/data/animations/dynamic_particles.led
@@ -1,0 +1,6 @@
+Variables:
+    loop_length:12
+Animations:
+    Particles spawn_rate:5+5*sin(2*pi*t) hue:100+80*sin(2*pi*t)
+Parameters:
+    brightness:150

--- a/src/led_ui/data/animations/dynamic_particles2.led
+++ b/src/led_ui/data/animations/dynamic_particles2.led
@@ -1,0 +1,6 @@
+Variables:
+    loop_length:6
+Animations:
+    Particles spawn_rate:50 hue:150+150*t hue_end:1 time_scale:60
+Parameters:
+    brightness:150

--- a/src/led_ui/data/animations/dynamic_wave.led
+++ b/src/led_ui/data/animations/dynamic_wave.led
@@ -1,0 +1,6 @@
+Variables:
+    loop_length:10
+Animations:
+    Rainbow hue:360*t speed:1
+Parameters:
+    brightness:200

--- a/src/led_ui/data/animations/dynamic_wave.led
+++ b/src/led_ui/data/animations/dynamic_wave.led
@@ -1,6 +1,6 @@
 Variables:
     loop_length:10
 Animations:
-    Rainbow hue:360*t speed:1
+    Rainbow repeat:2*sin(t*pi) speed:0
 Parameters:
     brightness:200

--- a/src/led_ui/data/parameter_map.json
+++ b/src/led_ui/data/parameter_map.json
@@ -64,7 +64,7 @@
   "PARAM_HUE": {
     "id": 0,
     "type": "int",
-    "value": 87,
+    "value": 301,
     "name": "Hue",
     "min": 0,
     "max": 360
@@ -80,7 +80,7 @@
   "PARAM_WIDTH": {
     "id": 3,
     "type": "int",
-    "value": 8,
+    "value": 1,
     "name": "Width",
     "min": 1,
     "max": 60
@@ -136,7 +136,7 @@
   "PARAM_POSITION": {
     "id": 14,
     "type": "int",
-    "value": 0,
+    "value": -61,
     "name": "Pos",
     "min": -255,
     "max": 255
@@ -296,7 +296,7 @@
   "PARAM_TIME_SCALE": {
     "id": 11,
     "type": "float",
-    "value": 34.109,
+    "value": 1.0,
     "name": "Time",
     "min": 0,
     "max": 200

--- a/src/lib/animations.cpp
+++ b/src/lib/animations.cpp
@@ -372,7 +372,7 @@ void SliderAnimation::update()
 {
     //  slider animation is just a gradient that positioned in the middle of the strip with a width and hue and repeat factor
     int position = numLEDs() / 2 + getInt(PARAM_POSITION);
-    int width = getInt(PARAM_WIDTH) * numLEDs();
+    int width = getInt(PARAM_WIDTH);
     float repeat = getFloat(PARAM_REPEAT);
     int brightness = getInt(PARAM_BRIGHTNESS);
     int hue = getInt(PARAM_HUE);
@@ -385,7 +385,6 @@ void SliderAnimation::update()
 
         if (val > width / 2)
         {
-            setPixel(i, {0, 0, 0}); // turn off pixel
         }
         else
         {

--- a/src/lib/stripState.cpp
+++ b/src/lib/stripState.cpp
@@ -274,9 +274,34 @@ void StripState::update()
 
     case LED_STATE_MULTI_ANIMATION:
     {
+        float t = 0.0f;
+        if (loopLength > 0)
+        {
+            unsigned long elapsed = millis() - timelineStart;
+            t = fmod((float)elapsed, loopLength) / loopLength;
+        }
 
         for (int i = 0; i < animations.size(); i++)
         {
+            if (i < dynamicParamExprs.size())
+            {
+                for (const auto &p : dynamicParamExprs[i])
+                {
+                    float val = evaluateExpression(p.second, scriptVariables, t);
+                    if (isFloatParameter(p.first))
+                    {
+                        animations[i]->setFloat(p.first, val);
+                    }
+                    else if (isIntParameter(p.first))
+                    {
+                        animations[i]->setInt(p.first, (int)val);
+                    }
+                    else if (isBoolParameter(p.first))
+                    {
+                        animations[i]->setBool(p.first, val != 0.0f);
+                    }
+                }
+            }
             animations[i].get()->update();
         }
     }
@@ -396,7 +421,34 @@ static float parseFactor(const String &expr, int &pos, const std::map<String, fl
     {
         return 0.0f;
     }
-    if ((token[0] >= '0' && token[0] <= '9') || token[0] == '.' || (token[0] == '-' && token.length() > 1))
+    skipSpaces(expr, pos);
+    if (pos < expr.length() && expr[pos] == '(')
+    {
+        // function call like sin(expr)
+        pos++; // skip '('
+        float arg = parseExpression(expr, pos, vars);
+        skipSpaces(expr, pos);
+        if (pos < expr.length() && expr[pos] == ')')
+            pos++;
+        if (token.equalsIgnoreCase("sin"))
+        {
+            val = sin(arg);
+        }
+        else if (token.equalsIgnoreCase("cos"))
+        {
+            val = cos(arg);
+        }
+        else if (token.equalsIgnoreCase("noise"))
+        {
+            val = inoise8((uint16_t)(arg * 1000)) / 255.0f;
+        }
+        else
+        {
+            // unknown function
+            val = 0.0f;
+        }
+    }
+    else if ((token[0] >= '0' && token[0] <= '9') || token[0] == '.' || (token[0] == '-' && token.length() > 1))
     {
         val = token.toFloat();
     }
@@ -406,6 +458,10 @@ static float parseFactor(const String &expr, int &pos, const std::map<String, fl
         if (it != vars.end())
         {
             val = it->second;
+        }
+        else if (token.equalsIgnoreCase("pi"))
+        {
+            val = M_PI;
         }
     }
     if (neg)
@@ -469,10 +525,12 @@ static float parseExpression(const String &expr, int &pos, const std::map<String
     return val;
 }
 
-static float evaluateExpression(const String &expr, const std::map<String, float> &vars)
+static float evaluateExpression(const String &expr, const std::map<String, float> &vars, float t = 0.0f)
 {
+    std::map<String, float> v = vars;
+    v["t"] = t;
     int pos = 0;
-    return parseExpression(expr, pos, vars);
+    return parseExpression(expr, pos, v);
 }
 
 bool StripState::parseAnimationScript(String script)
@@ -491,6 +549,7 @@ bool StripState::parseAnimationScript(String script)
         int start;
         int end;
         std::map<ParameterID, float> params;
+        std::map<ParameterID, String> exprs;
     };
     std::vector<AnimLine> anims;
 
@@ -621,6 +680,7 @@ bool StripState::parseAnimationScript(String script)
             int start = 0;
             int end = getNumLEDS() - 1;
             std::map<ParameterID, float> params;
+            std::map<ParameterID, String> exprs;
             for (int i = 1; i < tokens.size(); ++i)
             {
                 String t = tokens[i];
@@ -631,6 +691,7 @@ bool StripState::parseAnimationScript(String script)
                 String v = t.substring(c + 1);
                 k.trim();
                 v.trim();
+                String rawV = v;
                 if (variables.find(v) != variables.end())
                 {
                     v = String(variables[v]);
@@ -725,21 +786,53 @@ bool StripState::parseAnimationScript(String script)
                     }
                     if (pid != PARAM_UNKNOWN)
                     {
-                        params[pid] = v.toFloat();
+                        auto isNumeric = [](const String &s) {
+                            if (s.length() == 0)
+                                return false;
+                            for (int ii = 0; ii < s.length(); ++ii)
+                            {
+                                char ch = s[ii];
+                                if (!(isdigit(ch) || ch == '.' || ch == '-'))
+                                    return false;
+                            }
+                            return true;
+                        };
+                        bool dynamic = rawV.indexOf('t') != -1 || rawV.indexOf("sin") != -1 || rawV.indexOf("noise") != -1;
+                        if (!dynamic && !isNumeric(v))
+                        {
+                            dynamic = true;
+                        }
+                        if (dynamic)
+                        {
+                            exprs[pid] = rawV;
+                        }
+                        params[pid] = evaluateExpression(v, variables, 0.0f);
                     }
                 }
             }
-            anims.push_back({type, start, end, params});
+            anims.push_back({type, start, end, params, exprs});
         }
     }
 
     ledState = LED_STATE_MULTI_ANIMATION;
     animations.clear();
+    dynamicParamExprs.clear();
 
-     for (const auto &a : anims)
+    for (const auto &a : anims)
     {
         addAnimation(a.type, a.start, a.end, a.params);
+        dynamicParamExprs.push_back(a.exprs);
     }
+    scriptVariables = variables;
+    if (variables.find("loop_length") != variables.end())
+    {
+        loopLength = variables["loop_length"] * 1000.0f;
+    }
+    else if (variables.find("looplength") != variables.end())
+    {
+        loopLength = variables["looplength"] * 1000.0f;
+    }
+    timelineStart = millis();
     return true;
 }
 void StripState::replaceAnimation(int index, ANIMATION_TYPE animType, std::map<ParameterID, float> params)

--- a/src/lib/stripState.cpp
+++ b/src/lib/stripState.cpp
@@ -683,7 +683,8 @@ bool StripState::parseAnimationScript(String script)
                     }
                     if (pid != PARAM_UNKNOWN)
                     {
-                        auto isNumeric = [](const String &s) {
+                        auto isNumeric = [](const String &s)
+                        {
                             if (s.length() == 0)
                                 return false;
                             for (int ii = 0; ii < s.length(); ++ii)
@@ -704,6 +705,10 @@ bool StripState::parseAnimationScript(String script)
                             exprs[pid] = rawV;
                         }
                         params[pid] = evaluateExpression(v, variables, 0.0f);
+                        if (isVerbose())
+                        {
+                            Serial.printf("\tParameter %s = %s (%.2f)\n", k.c_str(), v.c_str(), params[pid]);
+                        }
                     }
                 }
             }
@@ -1102,7 +1107,7 @@ void StripState::update()
             animations[i].get()->update();
         }
     }
-        break;
+    break;
 
     case LED_STATE_POINT_CONTROL:
     {
@@ -1125,7 +1130,7 @@ void StripState::update()
             // Serial.printf("Point control LED %d out of range for strip %d\n", pointPosition, stripIndex);
         }
     }
-        break;
+    break;
     default:
         break;
     }

--- a/src/lib/stripState.h
+++ b/src/lib/stripState.h
@@ -8,6 +8,7 @@
 #include "parameterManager.h"
 #include "animations.h"
 #include <memory>
+#include <map>
 
 #include "animations.h"
 class StripState : public ParameterManager
@@ -29,6 +30,12 @@ private:
 
     std::vector<std::unique_ptr<StripAnimation>> animations;
     LED_STATE ledState = LED_STATE_IDLE;
+
+    // Dynamic parameter expressions per animation
+    std::vector<std::map<ParameterID, String>> dynamicParamExprs;
+    std::map<String, float> scriptVariables;
+    unsigned long timelineStart = 0;
+    float loopLength = 1000.0f; // milliseconds
 
 public:
     bool isActive = true;


### PR DESCRIPTION
## Summary
- expand expression parser to handle functions and time variable
- store dynamic parameter formulas in `StripState`
- evaluate parameter expressions on each frame using `t`

## Testing
- `make -C tests` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b8c931a908322ba1daae0c34c10f4