### PR TITLE
Add 3D model loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ There are two major components:
 1. Firmware written in C++ for the ESP32 (master and slave roles).
 2. A PyQt desktop interface in `src/led_ui` that communicates with the device.
 
+   The LED simulator includes a 3D view which can now load external `.stl` or
+   `.obj` models for visualization.  Use the **Load Model** button in the
+   interface to import a mesh and inspect how your animations map onto a real
+   object.
+
 The code uses a modular `ParameterManager` class so that each subsystem can expose tunable parameters.  See `shared.h` for enums describing menus, parameters and message types. Parameters are exchanged over serial/Mesh using the IDs from this header so that the C++ firmware and Python UI stay in sync.
 
 Recent updates added a few LED patterns including a falling bricks build-up effect and a "nebula" gradient that uses noise for subtle color variation. The bricks animation now supports a direction toggle and per-brick hue variance with a gradient towards `HueEnd`, while the nebula effect fades in using a noise-driven brightness.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ There are two major components:
    geometric forms appear crisp.  The LEDs can be displayed as billboards,
    spheres or cubes with a configurable radius.  LEDs are always drawn on top of
    the model and a **Show Ground** checkbox toggles a ground grid aligned with
-   the bottom of the loaded mesh.
+   the bottom of the loaded mesh.  A **Show Model** toggle lets you hide the
+   imported mesh to view only the LED positions.
 
 The code uses a modular `ParameterManager` class so that each subsystem can expose tunable parameters.  See `shared.h` for enums describing menus, parameters and message types. Parameters are exchanged over serial/Mesh using the IDs from this header so that the C++ firmware and Python UI stay in sync.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ There are two major components:
    The LED simulator includes a 3D view which can now load external `.stl` or
    `.obj` models for visualization.  Use the **Load Model** button in the
    interface to import a mesh and inspect how your animations map onto a real
-   object.
+   object.  Loaded meshes use simple lighting via a "shaded" shader so surfaces
+   display depth instead of appearing flat white.
 
 The code uses a modular `ParameterManager` class so that each subsystem can expose tunable parameters.  See `shared.h` for enums describing menus, parameters and message types. Parameters are exchanged over serial/Mesh using the IDs from this header so that the C++ firmware and Python UI stay in sync.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ conda env create -f src/led_ui/environment.yml
 conda activate led-ui
 ```
 
+The environment specification pins `numpy<2` and includes SciPy so that
+the `trimesh` package can load meshes without binary compatibility errors.
+
 Then build the executable from `offline_main.py` using the helper script.
 This step also compiles the small C++ simulators used for unit tests so
 they can run without a `make` installation:

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ There are two major components:
    `.obj` models for visualization.  Use the **Load Model** button in the
    interface to import a mesh and inspect how your animations map onto a real
    object.  Loaded meshes use sharp per-face lighting via a "shaded" shader so
-   geometric forms appear crisp.  The LEDs are always drawn on top of the model
-   and a **Show Ground** checkbox toggles a ground grid aligned with the bottom
-   of the loaded mesh.
+   geometric forms appear crisp.  The LEDs can be displayed as billboards,
+   spheres or cubes with a configurable radius.  LEDs are always drawn on top of
+   the model and a **Show Ground** checkbox toggles a ground grid aligned with
+   the bottom of the loaded mesh.
 
 The code uses a modular `ParameterManager` class so that each subsystem can expose tunable parameters.  See `shared.h` for enums describing menus, parameters and message types. Parameters are exchanged over serial/Mesh using the IDs from this header so that the C++ firmware and Python UI stay in sync.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ There are two major components:
    The LED simulator includes a 3D view which can now load external `.stl` or
    `.obj` models for visualization.  Use the **Load Model** button in the
    interface to import a mesh and inspect how your animations map onto a real
-   object.  Loaded meshes use simple lighting via a "shaded" shader so surfaces
-   display depth instead of appearing flat white.
+   object.  Loaded meshes use sharp per-face lighting via a "shaded" shader so
+   geometric forms appear crisp.  The LEDs are always drawn on top of the model
+   and a **Show Ground** checkbox toggles a ground grid aligned with the bottom
+   of the loaded mesh.
 
 The code uses a modular `ParameterManager` class so that each subsystem can expose tunable parameters.  See `shared.h` for enums describing menus, parameters and message types. Parameters are exchanged over serial/Mesh using the IDs from this header so that the C++ firmware and Python UI stay in sync.
 

--- a/src/led_ui/environment.yml
+++ b/src/led_ui/environment.yml
@@ -14,3 +14,4 @@ dependencies:
       - pyqtgraph
       - PyOpenGL
       - pyinstaller
+      - trimesh

--- a/src/led_ui/environment.yml
+++ b/src/led_ui/environment.yml
@@ -4,6 +4,8 @@ channels:
   - defaults
 dependencies:
   - python=3.10
+  - numpy<2
+  - scipy
   - pyqt=5
   - pyserial
   - pip

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -345,8 +345,13 @@ class LED3DWidget(QWidget):
             self.view.removeItem(self.model_item)
             self.model_item = None
 
-        item = gl.GLMeshItem(meshdata=md, smooth=True,
-                             drawFaces=True, drawEdges=False)
+        item = gl.GLMeshItem(
+            meshdata=md,
+            smooth=True,
+            drawFaces=True,
+            drawEdges=False,
+            shader="shaded",
+        )
         item.setGLOptions("opaque")
         self.model_item = item
         self.view.addItem(item)

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -38,7 +38,12 @@ class LED3DWidget(QWidget):
         self.view.opts['distance'] = 4
         self.scatter = gl.GLScatterPlotItem()
         # keep LEDs visible even when a model overlaps
-        self.scatter.setGLOptions({GL.GL_DEPTH_TEST: False})
+        try:
+            # modern pyqtgraph expects raw GL constants
+            self.scatter.setGLOptions({GL.GL_DEPTH_TEST: False})
+        except Exception:
+            # fallback for older pyqtgraph versions that used string options
+            self.scatter.setGLOptions({'depthTest': False})
         self.view.addItem(self.scatter)
 
         self.current_shape = None

--- a/src/led_ui/led3dwidget.py
+++ b/src/led_ui/led3dwidget.py
@@ -6,6 +6,7 @@ from PyQt5.QtGui import QColor
 from parameter_menu import ParameterIDMap
 import numpy as np
 import trimesh
+from OpenGL import GL
 
 
 class LED3DWidget(QWidget):
@@ -37,7 +38,7 @@ class LED3DWidget(QWidget):
         self.view.opts['distance'] = 4
         self.scatter = gl.GLScatterPlotItem()
         # keep LEDs visible even when a model overlaps
-        self.scatter.setGLOptions({'depthTest': False})
+        self.scatter.setGLOptions({GL.GL_DEPTH_TEST: False})
         self.view.addItem(self.scatter)
 
         self.current_shape = None


### PR DESCRIPTION
## Summary
- allow loading meshes in the PyQt simulator
- add trimesh dependency
- document the new feature

## Testing
- `python -m py_compile src/led_ui/led3dwidget.py`
- `make -C tests` *(fails: gtest headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f193802e88322b08f4f74b5242019