### PR TITLE
Fix SPI sharing

### DIFF
--- a/src/lib/displayManager.cpp
+++ b/src/lib/displayManager.cpp
@@ -9,15 +9,19 @@
 // #define DC_PIN 32  // Data Command control pin
 // #define RST_PIN 33 // Reset pin (could connect to NodeMCU RST, see next line)
 // #define BL_PIN 13  // Backlight control pin (optional, can be connected to GPIO)
-void DisplayManager::begin(int DC_PIN, int CS_PIN, int SCLK_PIN, int MOSI_PIN, int RST_PIN, int BL_PIN)
+void DisplayManager::begin(int DC_PIN, int CS_PIN, int SCLK_PIN, int MOSI_PIN,
+                           int RST_PIN, int BL_PIN, SPIClass *spi,
+                           int MISO_PIN)
 
 {
-    Arduino_DataBus *bus = new Arduino_ESP32SPI(
+    Arduino_DataBus *bus = new Arduino_HWSPI(
         DC_PIN,   // DC
         CS_PIN,   // CS
         SCLK_PIN, // SCK
         MOSI_PIN, // MOSI
-        -1        // MISO (not used)
+        MISO_PIN, // MISO pin (optional)
+        spi,      // shared SPI bus
+        true      // is_shared_interface
     );
     gfx = new Arduino_ST7796(
         bus, RST_PIN, 0, true, 320, 480, 0, 80);

--- a/src/lib/displayManager.h
+++ b/src/lib/displayManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifdef DISPLAY_MANAGER
 #include <Arduino_GFX_Library.h>
+#include <SPI.h>
 
 class DisplayManager
 {
@@ -14,7 +15,9 @@ public:
     void showGraph(float *data, int len, int x, int y, int w, int h);
     void showParticles();
     void clear();
-    void begin(int DC_PIN, int CS_PIN, int SCLK_PIN, int MOSI_PIN, int RST_PIN, int BL_PIN);
+    void begin(int DC_PIN, int CS_PIN, int SCLK_PIN, int MOSI_PIN,
+               int RST_PIN, int BL_PIN, SPIClass *spi = &SPI,
+               int MISO_PIN = -1);
     void showBars(const int *values, int len, int x, int y, int w, int h, uint16_t color = 0xFFFF);
 
 private:

--- a/src/tess_controller.cpp
+++ b/src/tess_controller.cpp
@@ -72,7 +72,8 @@ void setup()
                                     &sensorSPI);
 #if DISPLAY_MANAGER
   displayManager = new DisplayManager();
-  displayManager->begin(DISPLAY_DC, DISPLAY_CS, SCL_PIN, SDA_PIN, DISPLAY_RST, DISPLAY_BL);
+  displayManager->begin(DISPLAY_DC, DISPLAY_CS, SCL_PIN, SDA_PIN,
+                        DISPLAY_RST, DISPLAY_BL, &sensorSPI, DOUT_PIN);
   //  turn on the display backlight
 
   displayManager->showText("Tesseratica Controller", 10, 10, 2, 0xFFFF);


### PR DESCRIPTION
## Summary
- allow DisplayManager to share SPIClass with sensors
- use Arduino_HWSPI for display bus

## Testing
- `make && ./falling_bricks_test && ./strip_state_test`


------
https://chatgpt.com/codex/tasks/task_e_6879b6a6c08083229bd02f3c4d2df3a4