### PR TITLE
Add display double buffering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 *.pyc
 src\led_ui\data\configurations
 tests/falling_bricks_test
+tests/strip_state_test
 tests/*.o
 tests/*.log
 tools/simulate_bricks

--- a/src/lib/displayManager.h
+++ b/src/lib/displayManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #ifdef DISPLAY_MANAGER
 #include <Arduino_GFX_Library.h>
-#include <GFXcanvas16.h>
+#include <Adafruit_GFX.h>
 #include <SPI.h>
 
 class DisplayManager

--- a/src/lib/displayManager.h
+++ b/src/lib/displayManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifdef DISPLAY_MANAGER
 #include <Arduino_GFX_Library.h>
+#include <GFXcanvas16.h>
 #include <SPI.h>
 
 class DisplayManager
@@ -23,5 +24,7 @@ public:
 
 private:
     Arduino_GFX *gfx;
+    GFXcanvas16 *canvas = nullptr;
+    void flush();
 };
 #endif


### PR DESCRIPTION
## Summary
- allocate a GFXcanvas16 buffer in `DisplayManager`
- draw text, bars, graphs and particles to the canvas and flush once per call
- provide `flush()` helper
- ignore compiled `strip_state_test` output

## Testing
- `make -C tests clean`
- `make -C tests`
- `./tests/falling_bricks_test`
- `./tests/strip_state_test`


------
https://chatgpt.com/codex/tasks/task_e_6879dd3ae46c8322b770378a78950ff4