### PR TITLE
Fix display of parameter bars

### DIFF
--- a/src/lib/displayManager.cpp
+++ b/src/lib/displayManager.cpp
@@ -250,20 +250,33 @@ void DisplayManager::showParticles()
 #endif
 }
 
-void DisplayManager::displayParameterBars(const std::vector<ParameterDisplayItem> &items, int selectedIndex)
+void DisplayManager::displayParameterBars(const std::vector<ParameterDisplayItem> &items,
+                                          int selectedIndex, const std::string &header)
 {
     const int baseX = 20;
     const int barWidth = 40;
-    const int spacing = 10;
+    const int maxBars = std::min((int)items.size(), 5);
+    const int availableWidth = gfx->width() - 2 * baseX;
+    int spacing = 0;
+    if (maxBars > 1)
+    {
+        spacing = (availableWidth - barWidth * maxBars) / (maxBars - 1);
+        if (spacing < 0)
+            spacing = 0;
+    }
     const int totalHeight = 100;
     const int baseY = gfx->height() - 40;
 
     clear();
-    for (size_t i = 0; i < items.size() && i < 5; ++i)
+    if (!header.empty())
+    {
+        showText(header, 10, 10, 2, 0xFF);
+    }
+    for (int i = 0; i < maxBars; ++i)
     {
         int x = baseX + i * (barWidth + spacing);
-        drawBar(i, baseX, baseY, barWidth + spacing, items[i].normalized, totalHeight, items[i].normalized);
-        if (static_cast<int>(i) == selectedIndex)
+        drawBar(i, baseX + i * spacing, baseY, barWidth, items[i].normalized, totalHeight, items[i].normalized);
+        if (i == selectedIndex)
         {
 #if DISPLAY_USE_DOUBLE_BUFFER
             if (canvas)

--- a/src/lib/displayManager.h
+++ b/src/lib/displayManager.h
@@ -70,7 +70,8 @@ public:
             showText(menuItems[i], 10, y, 2, textColor);
         }
     }
-    void displayParameterBars(const std::vector<ParameterDisplayItem> &items, int selectedIndex = -1);
+    void displayParameterBars(const std::vector<ParameterDisplayItem> &items, int selectedIndex = -1,
+                              const std::string &header = "");
 
 private:
     Arduino_GFX *gfx;

--- a/src/master.h
+++ b/src/master.h
@@ -82,6 +82,7 @@ public:
     void handleJson(JsonDocument &doc);
     bool handleParameterMessage(parameter_message parameter);
     void menuChangedParameters(parameter_message listener);
+    void renderParameterMenu();
 };
 
 #endif


### PR DESCRIPTION
## Summary
- fix drawing of parameter bars
- adjust sensor values to parameter ranges
- show menu path while editing parameters
- refactor drawing of parameter bars

## Testing
- `make clean && make` in `tests`
- `./falling_bricks_test && ./strip_state_test`

------
https://chatgpt.com/codex/tasks/task_e_687c9cadecc08322a3dc82f1b1721b82