### PR TITLE
Fix I2C slave initialization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,10 +23,7 @@ lib_deps =
         fastled/FastLED@^3.6.0
         bblanchon/ArduinoJson@^7.0.4
 		moononournation/GFX Library for Arduino@^1.6.0
-[env:master]
-build_flags = -D MASTER_BOARD -D MESH_NET -D USE_LEDS
-upload_port = COM3
-
+ 
 [env:tesseratica_controller]
 build_flags = 	-D SLAVE_NAME=\"TesseraticaController\" 
   				-D TESS_BOARD   
@@ -61,7 +58,6 @@ build_flags =   -D LED_SLAVE
 				-D SLAVE_NAME=\"LEDSlave\"   
 				-D USE_LEDS 
 				-D TESS_MENU
-			 
 				-D USE_I2C_SLAVE
  
 

--- a/src/boardConfigs/tessControllerPins.h
+++ b/src/boardConfigs/tessControllerPins.h
@@ -1,7 +1,7 @@
 #ifdef TESS_BOARD
 #define SDA_PIN 9
 #define SCL_PIN 18
-#define I2C_ADDRESS 0x12
+#define I2C_ADDRESS 0x10
 #define DOUT_PIN 8
 #define MCP_CS 12
 #define AUDIO_BCLK_PIN 37

--- a/src/led_ui/data/parameter_map.json
+++ b/src/led_ui/data/parameter_map.json
@@ -64,7 +64,7 @@
   "PARAM_HUE": {
     "id": 0,
     "type": "int",
-    "value": 260,
+    "value": 205,
     "name": "Hue",
     "min": 0,
     "max": 360
@@ -112,7 +112,7 @@
   "PARAM_BRIGHTNESS": {
     "id": 2,
     "type": "int",
-    "value": 58,
+    "value": 19,
     "name": "Brightness",
     "min": 0,
     "max": 255

--- a/src/lib/i2c_manager.cpp
+++ b/src/lib/i2c_manager.cpp
@@ -44,6 +44,25 @@ void I2CManager::broadcastString(const std::string &message) {
     }
 }
 
+bool I2CManager::ping(uint8_t address) {
+    Wire.beginTransmission(address);
+    uint8_t error = Wire.endTransmission();
+    return error == 0;
+}
+
+void I2CManager::testSlaves() {
+    for (auto addr : _slaves) {
+        bool ok = ping(addr);
+        Serial.print("I2C slave 0x");
+        Serial.print(addr, HEX);
+        if (ok) {
+            Serial.println(" responded");
+        } else {
+            Serial.println(" not responding");
+        }
+    }
+}
+
 void I2CManager::sendSync(uint32_t timeMs) {
     std::string msg = "SYNC:" + std::to_string(timeMs);
     broadcastString(msg);

--- a/src/lib/i2c_manager.cpp
+++ b/src/lib/i2c_manager.cpp
@@ -18,9 +18,9 @@ void I2CManager::beginMaster() {
 }
 
 void I2CManager::beginSlave(uint8_t address, I2CMessageHandler handler) {
-    // start using custom pins and address
-    Wire.begin(SLAVE_SDA, SLAVE_SCL);
-    Wire.beginTransmission(address);
+    // Initialize as a slave on the given address using the custom pins.
+    // `Wire.begin` needs the address parameter to enable slave mode on ESP32.
+    Wire.begin(address, SLAVE_SDA, SLAVE_SCL);
     _handler = handler;
     instance = this;
     Wire.onReceive(I2CManager::onReceiveStatic);

--- a/src/lib/i2c_manager.cpp
+++ b/src/lib/i2c_manager.cpp
@@ -17,10 +17,10 @@ void I2CManager::beginMaster() {
     instance = this;
 }
 
-void I2CManager::beginSlave(uint8_t address, I2CMessageHandler handler) {
+void I2CManager::beginSlave(uint8_t addr, I2CMessageHandler handler) {
     // Initialize as a slave on the given address using the custom pins.
     // `Wire.begin` needs the address parameter to enable slave mode on ESP32.
-    Wire.begin(address, SLAVE_SDA, SLAVE_SCL);
+    Wire.begin(addr, SLAVE_SDA, SLAVE_SCL);
     _handler = handler;
     instance = this;
     Wire.onReceive(I2CManager::onReceiveStatic);
@@ -34,10 +34,12 @@ void I2CManager::sendString(uint8_t address, const std::string &message) {
     Wire.endTransmission();
 }
 
-void I2CManager::broadcastString(const std::string &message) {
+void I2CManager::broadcastString(const std::string &message,bool print) {
     if(isVerbose()) {
-        Serial.print("Broadcasting I2C message: ");
-        Serial.println(message.c_str());
+        if(print){
+            Serial.print("Broadcasting I2C message: ");
+            Serial.println(message.c_str());
+        }
     }
     for (auto addr : _slaves) {
         sendString(addr, message);
@@ -65,7 +67,7 @@ void I2CManager::testSlaves() {
 
 void I2CManager::sendSync(uint32_t timeMs) {
     std::string msg = "SYNC:" + std::to_string(timeMs);
-    broadcastString(msg);
+    broadcastString(msg,false);
 }
 
 void I2CManager::onReceiveStatic(int numBytes) {

--- a/src/lib/i2c_manager.h
+++ b/src/lib/i2c_manager.h
@@ -14,6 +14,8 @@ class I2CManager {
     void addSlave(uint8_t address);
     void sendString(uint8_t address, const std::string &message);
     void broadcastString(const std::string &message);
+    bool ping(uint8_t address);
+    void testSlaves();
     void sendSync(uint32_t timeMs);
 
   private:

--- a/src/lib/i2c_manager.h
+++ b/src/lib/i2c_manager.h
@@ -13,7 +13,7 @@ class I2CManager {
     void beginSlave(uint8_t address, I2CMessageHandler handler);
     void addSlave(uint8_t address);
     void sendString(uint8_t address, const std::string &message);
-    void broadcastString(const std::string &message);
+    void broadcastString(const std::string &message,bool print = true);
     bool ping(uint8_t address);
     void testSlaves();
     void sendSync(uint32_t timeMs);

--- a/src/lib/string_utils.h
+++ b/src/lib/string_utils.h
@@ -31,6 +31,14 @@ inline bool contains(const std::string &str, const std::string &substr)
 {
     return str.find(substr) != std::string::npos;
 }
+inline bool containsIgnoreCase(const std::string &str, const std::string &substr)
+{
+    std::string strLower = str;
+    std::string substrLower = substr;
+    toLowerCase(strLower);
+    toLowerCase(substrLower);
+    return strLower.find(substrLower) != std::string::npos;
+}
 inline void replace(std::string &str, const std::string &from, const std::string &to)
 {
     size_t start_pos = 0;

--- a/src/lib/stripState.cpp
+++ b/src/lib/stripState.cpp
@@ -25,7 +25,7 @@ ANIMATION_TYPE getAnimationTypeFromName(const std::string &name)
 {
     for (const auto &pair : ANIMATION_TYPE_NAMES)
     {
-        if (contains(name, pair.second))
+        if (containsIgnoreCase(name, pair.second))
         {
             return pair.first;
         }
@@ -802,9 +802,10 @@ bool StripState::handleTextMessage(std::string command)
         auto animName = animparts[1];
         trim(animName);
 
-        if (animName == "POINT_CONTROL")
+        if (containsIgnoreCase(animName, "point")  )
         {
             ledState = LED_STATE_POINT_CONTROL;
+            setInt(PARAM_CURRENT_LED, 0);
             if (isVerbose())
             {
                 LOG_PRINTLN("Set LED state to POINT_CONTROL");
@@ -814,7 +815,7 @@ bool StripState::handleTextMessage(std::string command)
         ANIMATION_TYPE animType = getAnimationTypeFromName(animName);
         if (animType == ANIMATION_TYPE_NONE)
         {
-            LOG_PRINTF("Unknown animation type %s\n", animName.c_str());
+          
             return false;
         }
 

--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -58,6 +58,7 @@ SlaveBoard::SlaveBoard(SerialManager *serialManager)
     i2cManager.addSlave(0x10);
     i2cManager.addSlave(0x11);
     i2cManager.addSlave(0x12);
+    i2cManager.testSlaves();
 #endif
 #ifdef LED_SLAVE
 #ifndef I2C_ADDRESS


### PR DESCRIPTION
## Summary
- ensure Wire.begin uses the slave address so ESP32 enters slave mode
- remove erroneous beginTransmission call in I2C slave setup

## Testing
- `cd tests && make` *(fails: BasicInterpreter.h missing overload for String(double) and constrain function)*

------
https://chatgpt.com/codex/tasks/task_e_689ec89bfc188322a0e853643c64102a